### PR TITLE
Set `:min-bb-version` in bb.edn

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,4 +1,5 @@
-{:paths ["src" "resources" "bb"]
+{:min-bb-version "0.9.161"
+ :paths ["src" "resources" "bb"]
  :tasks {:requires ([tasks :as t])
          build (t/build-cherry-npm-package)
          publish (t/publish)


### PR DESCRIPTION
So folks on older versions running into issues like in https://github.com/borkdude/cherry/issues/24#issuecomment-1204324085 see a warning:
```
bb tasks
WARNING: this project requires babashka 0.9.161 or newer, but you have: 0.7.7
The following tasks are available:

build  
publish
watch  
test    Run tests
```